### PR TITLE
USI-LS Patch Update

### DIFF
--- a/GameData/NearFutureSpacecraft/Patches/NFSpacecraftUSILifeSupport.cfg
+++ b/GameData/NearFutureSpacecraft/Patches/NFSpacecraftUSILifeSupport.cfg
@@ -1,52 +1,77 @@
 // USI Life Support habitat and recycler functions
 
-//PPD-24 Itinerant Service Container
-@PART[utilityCabin]:NEEDS[USILifeSupport]
-{
-	%MODULE[ModuleLifeSupport] { }
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 1025 //100 * crew capacity + 100 * Kerbal-Months
-		%maxAmount = 1025
-	}
-
-	MODULE
-	{
-		name = ModuleHabitation
-		KerbalMonths = 8.25 //mass * 5
-	}
-
-	%MODULE[USI_ModuleFieldRepair] { }
-}
-
 //Mk3-9 Orbital Command Pod
 @PART[mk3-9pod]:NEEDS[USILifeSupport]
 {
-	%MODULE[ModuleLifeSupport] { }
-
-	%RESOURCE[ReplacementParts]
-	{
-		%amount = 200 //100 * crew capacity + 100 * Kerbal-Months
-		%maxAmount = 200
-	}
-
 	MODULE
 	{
 		name = ModuleLifeSupportRecycler
 		CrewCapacity = 3
-		RecyclePercent = .7 //mass / crew capacity; maximum .75
+		RecyclePercent = .25
 		ConverterName = Life Support
-		tag = Life Support
 		StartActionName = Start Life Support
 		StopActionName = Stop Life Support
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = .6
+			Ratio = 1
 		}
 	}
+}
 
-	%MODULE[USI_ModuleFieldRepair] { }
+//PPD-1 Heavy Command Module
+@PART[inlineCmdPod]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = ModuleLifeSupportRecycler
+		CrewCapacity = 6
+		RecyclePercent = .5
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
+	}
+}
+
+//PPD-24 Itinerant Service Container
+@PART[utilityCabin]:NEEDS[USILifeSupport]
+{
+	%MODULE[ModuleLifeSupport]{}
+	%MODULE[USI_ModuleFieldRepair]{}
+
+	MODULE
+	{
+		name = ModuleHabitation
+		BaseKerbalMonths = #$/mass$ 
+		@BaseKerbalMonths *= 10
+		@BaseKerbalMonths -= #$/CrewCapacity$
+		CrewCapacity = #$/CrewCapacity$
+		BaseHabMultiplier = 0
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = #$../BaseKerbalMonths$ 
+			@Ratio *= .25
+		}
+	}
+	
+	!RESOURCE[ReplacementParts]{}
+	RESOURCE
+	{
+		name = ReplacementParts
+		amount = #$/mass$ 
+		@amount *= 1000
+		maxAmount = #$amount$ 
+		
+	}
 }


### PR DESCRIPTION
This replaces the existing patch for USI-LS 0.5.x. RoverDude reworked and re-balanced many aspects of USI-LS.  This patch updates and balances the parts in NFS. Here are some of the changes in the new version of USI-LS:

- For the most part everything is balanced based on mass (habitation time, habitation multipliers, and recyclers)
- USI-LS automatically calculates habitation based on crew capacity (default .25 kerbal months per crew capacity)
- USI-LS adds ModuleLifeSupport, ModuleFieldRepair, and ReplacementParts to all parts with crew capacity
 -ModuleHabitation is now a converter and requires electric charge
- ModuleHabitation provides extra hab time and is only used on appropriate parts

Changes for NFS:

- Reduced mk3-9pod  recycler from .7 to .25 for balance with MKS Salamander and Stock Science Lab

- Added .5 recycler to PPD-1 Heavy Command Module

- Added ModuleHabitation to PPD-24 Itinerant Service Container balanced against USI-LS changes to stock Hitchhiker; RD is currently using (Mass x 10 - CrewCapacity) for BaseKerbalMonths and (Mass x 1000) for replacement parts