### PR TITLE
Round up part costs to avoid compilation errors, as costs now need to be integers.

### DIFF
--- a/GameData/NearFutureSpacecraft/Parts/Engine/orbitalEngine/orbitalEngine-375.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/Engine/orbitalEngine/orbitalEngine-375.cfg
@@ -94,7 +94,7 @@ PART
 	TechRequired = veryHeavyRocketry
 	entryCost = 27720
 
-	cost = 12783.6
+	cost = 12784
 	category = Engine
 	subcategory = 0
 	title = LV-T18 Liquid Fuel Engine Cluster

--- a/GameData/NearFutureSpacecraft/Parts/FuelTank/serviceTank/servicetank-25.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/FuelTank/serviceTank/servicetank-25.cfg
@@ -21,7 +21,7 @@ PART
 
 	TechRequired = advFuelSystems
 	entryCost = 6500
-	cost = 1862.5
+	cost = 1863
 	category = Payload
 	subcategory = 0
 	title = FL-T6000 Service Tank


### PR DESCRIPTION
Parts fail with compile error during KSP startup otherwise.

See: http://forum.kerbalspaceprogram.com/index.php?/topic/154196-solved-ksp-cannot-compile-parts/