### PR TITLE
Fix for incorrectly swapped costs of FL-R-B750 (monoprop-tank-25-3) and FL-R-B3000 (monoprop-tank-25-1)

### DIFF
--- a/GameData/NearFutureSpacecraft/Parts/FuelTank/monoprop-tank/monoprop-tank-25-1.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/FuelTank/monoprop-tank/monoprop-tank-25-1.cfg
@@ -19,7 +19,7 @@ PART
 	node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 	TechRequired = largeVolumeContainment
 	entryCost = 14400
-	cost = 1300
+	cost = 5200
 	category = FuelTank
 	subcategory = 0
 	title = FL-R-B3000 Monopropellant Tank

--- a/GameData/NearFutureSpacecraft/Parts/FuelTank/monoprop-tank/monoprop-tank-25-3.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/FuelTank/monoprop-tank/monoprop-tank-25-3.cfg
@@ -19,7 +19,7 @@ PART
 	node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 	TechRequired = advFuelSystems
 	entryCost = 14400
-	cost = 5200
+	cost = 1300
 	category = FuelTank
 	subcategory = 0
 	title = FL-R-B750 Monopropellant Tank


### PR DESCRIPTION
The costs in the .cfg files for these two tanks appear to have been inverted:

The FL-R-B750 is the smaller tank, but has a cost of 5200, higher than the larger FL-R-B3000, which has a cost of 1300. This can result in the strange situation where an empty FL-R-B3000 tank has a cost of 0 in the VAB!

It seems all other similar monoprop tanks have a Cost/Capacity ratio of 1.73, so I've un-swapped the two costs, which brings them both to this value as well.