### PR TITLE
Give NF RCS parts PhysicsSignificance = 1

### DIFF
--- a/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-aero/rcsblock-aero-5way-1.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-aero/rcsblock-aero-5way-1.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 2300
+	PhysicsSignificance = 1
 	bulkheadProfiles = srf
 	tags = cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate shielded nearfuture
 

--- a/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-2way-45-1.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-2way-45-1.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	// --- rcs module parameters ---
 	bulkheadProfiles = srf

--- a/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-2way-45-2.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-2way-45-2.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 	bulkheadProfiles = srf
 	tags = cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate orion dual nearfuture
 

--- a/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-3way-1.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-3way-1.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	// --- rcs module parameters ---
 

--- a/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-4way-1.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-4way-1.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	// --- rcs module parameters ---
 

--- a/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-5way-1.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-5way-1.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	// --- rcs module parameters ---
 

--- a/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-linear-1.cfg
+++ b/GameData/NearFutureSpacecraft/Parts/RCS/rcsblock-orbital/rcsblock-orbital-linear-1.cfg
@@ -43,6 +43,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 15
 	maxTemp = 1700
+	PhysicsSignificance = 1
 
 	// --- rcs module parameters ---
 


### PR DESCRIPTION
I was playing around with the Near Future mods, making myself a nice interplanetary mothership (and really loving the Magnetoplasmadynamic engines!) and I noticed that the Near Future RCS thruster parts did not have PhysicsSignificance = 1 set, while all the stock RCS thruster parts do.

It seems the stock game makes RCS ports and other such low-mass parts "physicsless" for performance reasons, and I decided to test if this was in fact the case. I set up a huge ship with 296 parts, 94 of them being NF RCS thrusters. When changing them to "PhysicsSignificance = 1", I observed a 10% improvement in physics frame updating as measured by the MemGraph mod.

As such, I've given all the RCS blocks across the NF mods PhysicsSignificance = 1, as well as the Atmospheric Sounder part and the radially-attachable Capacitors from NF Electrical, as they are very similar to the stock science experiment parts and radial batteries, respectively, which are also "physicsless".

(This message accompanies three pull requests for NF Propulsion, NF Electrical, and NF Spacecraft.)