### PR TITLE
Changed USI Life Support Patch (#1)

### DIFF
--- a/GameData/NearFutureSpacecraft/Patches/NFSpacecraftUSILifeSupport.cfg
+++ b/GameData/NearFutureSpacecraft/Patches/NFSpacecraftUSILifeSupport.cfg
@@ -41,7 +41,7 @@
 }
 
 //Mk4-1 Heavy Command Module
-@PART[inlineCmdPod]:NEEDS[USILifeSupport]
+@PART[mk4-1pod]:NEEDS[USILifeSupport]
 {
 	MODULE
 	{


### PR DESCRIPTION
Issue raised in thread by FillipeC, changed MK4-1 Heavy Command Module to mk4-1pod, as suggested by FillipeC.