### PR TITLE
Fix LV-601-4 switcher

### DIFF
--- a/Extras/OrbitalLFOEngines/OrbitalEnginesLFO.cfg
+++ b/Extras/OrbitalLFOEngines/OrbitalEnginesLFO.cfg
@@ -57,7 +57,7 @@
 }
 @PART[orbital-engine-375]
 {
-	@MODULE[ModuleB9PartSwitch]
+	@MODULE[ModuleB9PartSwitch]:HAS[#switcherDescription[Fuel?Tanks]]
 	{
 		@SUBTYPE[Integrated]
 		{


### PR DESCRIPTION
There are two modules 'ModuleB9PartSwitch' on this engine, patch didn't work