### PR TITLE
Add Snacks recycler & soil storage to Itinerant

### DIFF
--- a/GameData/NearFutureSpacecraft/Localization/en-us.cfg
+++ b/GameData/NearFutureSpacecraft/Localization/en-us.cfg
@@ -200,5 +200,10 @@ Localization
     #LOC_NFSpacecraft_Action_StopUSIHab = Stop Habitat
     #LOC_NFSpacecraft_Action_ToggleUSIHab = Toggle Habitat
 
+    // Snacks
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_ConverterName = Soil Recycler
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_StartActionName = Start Soil Recycler
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_StopActionName = Stop Soil Recycler
+
   }
 }

--- a/GameData/NearFutureSpacecraft/Localization/ru.cfg
+++ b/GameData/NearFutureSpacecraft/Localization/ru.cfg
@@ -209,5 +209,10 @@ Localization
     #LOC_NFSpacecraft_Action_StartUSIHab = Включить обитаемый модуль
     #LOC_NFSpacecraft_Action_StopUSIHab = Выключить обитаемый модуль
     #LOC_NFSpacecraft_Action_ToggleUSIHab = Переключить обитаемый модуль
+
+    // Snacks
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_ConverterName = Переработка почвы
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_StartActionName = Запуск переработки почвы
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_StopActionName = Остановить переработку почвы
   }
 }

--- a/GameData/NearFutureSpacecraft/Localization/zh-cn.cfg
+++ b/GameData/NearFutureSpacecraft/Localization/zh-cn.cfg
@@ -201,5 +201,10 @@ Localization
     #LOC_NFSpacecraft_Action_StopUSIHab = 关闭Habitat
     #LOC_NFSpacecraft_Action_ToggleUSIHab = 开关Habitat
 
+    // Snacks
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_ConverterName = 土壤回收装置
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_StartActionName = 启动土壤回收装置
+    #LOC_NFSpacecraft_Snacks_SoilRecycler_StopActionName = 停止土壤回收装置
+
   }
 }

--- a/GameData/NearFutureSpacecraft/Patches/NFSpacecraftSnacks.cfg
+++ b/GameData/NearFutureSpacecraft/Patches/NFSpacecraftSnacks.cfg
@@ -1,0 +1,64 @@
+// Snacks! life support recycler functions
+
+//RPD-12 Itinerant Service Compartment
+@PART[utility-pod-25]:NEEDS[Snacks]:FOR[NearFutureSpacecraft]
+{
+	MODULE
+	{
+		name = SoilRecycler
+		ConverterName = #LOC_NFSpacecraft_Snacks_SoilRecycler_ConverterName // #LOC_NFSpacecraft_Snacks_SoilRecycler_ConverterName = Soil Recycler
+		StartActionName = #LOC_NFSpacecraft_Snacks_SoilRecycler_StartActionName // #LOC_NFSpacecraft_Snacks_SoilRecycler_StartActionName = Start Soil Recycler
+		StopActionName = #LOC_NFSpacecraft_Snacks_SoilRecycler_StopActionName // #LOC_NFSpacecraft_Snacks_SoilRecycler_StopActionName = Stop Soil Recycler
+		AutoShutdown = false
+		GeneratesHeat = false
+		UseSpecialistBonus = true
+		ExperienceEffect = ScienceSkill
+		EfficiencyBonus = 1.0
+		// default
+		RecyclerCapacity = 1
+		// use CrewCapacity for RecyclerCapacity
+		@RecyclerCapacity *= #$../CrewCapacity$
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Soil
+			Ratio = 0.00004630
+			FlowMode = ALL_VESSEL
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 3
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Snacks
+			Ratio = 0.00004630
+			DumpExcess = false
+			FlowMode = ALL_VESSEL
+		}
+	}
+	//Because we are directly monitoring converters,
+	//ModuleQualityControl has to appear in the config
+	//AFTER all the converters in the part.
+	MODULE:NEEDS[BARIS]
+	{
+		name = ModuleQualityControl
+		quality = 65
+		mtbf = 100
+		monitorConverters = true //WARNING: this is a performance hit.
+	}
+
+	// Note, Snacks mod adds Snacks capacity to crewed parts automatically.
+	// Soil capacity is not automatic since only parts with recyclers
+	// should have it.
+	RESOURCE
+	{
+		name = Soil
+		amount = 0
+		maxAmount = 50
+		@maxAmount *= #$../CrewCapacity$
+	}
+
+	@tags ^= :$: cck-lifesupport:
+}


### PR DESCRIPTION
The Snacks mod adds a `SoilRecycler` module and Soil `RESOURCE` block to several stock hab parts, including the Hitchhiker.  SSPXR does the same with its hab parts.  The Itinerant is basically a half-capacity version of the Hitchhiker, so it ought have the same features.

This is basically just a copy of the relevant portions of `SSPXR-Snacks.cfg` from the SSPXR mod.  I've copied the recycler's localized strings in the three languages for which SSPXR has them: English, Russian, and Chinese.  (Other languages lack translations for the Snacks recycler strings, both here and in SSPXR.)